### PR TITLE
Removed duplicate definitions.

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -198,10 +198,13 @@ typedef struct __attribute__((__packed__)) {
 
 /** Interface TX function */
 typedef struct csp_iface_s csp_iface_t;
+
+/* Nexthop typedef:
+ * Note this has to match the nexthop type in the iface structure */
 typedef int (*nexthop_t)(struct csp_iface_s * interface, csp_packet_t *packet, uint32_t timeout);
 
 /** Interface struct */
-typedef struct csp_iface_s {
+struct csp_iface_s {
 	const char *name;			/**< Interface name (keep below 10 bytes) */
 	void * driver;				/**< Pointer to interface handler structure */
 	nexthop_t nexthop;			/**< Next hop function */
@@ -219,11 +222,7 @@ typedef struct csp_iface_s {
 	uint32_t rxbytes;			/**< Received bytes */
 	uint32_t irq;				/**< Interrupts */
 	struct csp_iface_s *next;	/**< Next interface */
-} csp_iface_t;
-
-/* Nexthop typedef:
- * Note this has to match the nexthop type in the iface structure */
-typedef int (*nexthop_t)(csp_iface_t * interface, csp_packet_t *packet, uint32_t timeout);
+};
 
 /**
  * This define must be equal to the size of the packet overhead in csp_packet_t.


### PR DESCRIPTION
Duplicate definitions in csp.h caused compile errors with avr-gcc version < 4.6[1].

Specifically, the compile error was (when using makefile from subsystems directory):

```
In file included from ../../../../libcsp/src/arch/freertos/csp_queue.c:28:0:
../lib/libcsp/include/csp/csp.h:222:3: error: redefinition of typedef ‘csp_iface_t’
../lib/libcsp/include/csp/csp.h:200:28: note: previous declaration of ‘csp_iface_t’ was here
../lib/libcsp/include/csp/csp.h:226:15: error: redefinition of typedef ‘nexthop_t’
../lib/libcsp/include/csp/csp.h:201:15: note: previous declaration of ‘nexthop_t’ was here
```

[1] typedef redefinition is a part of C11 and implemented in avr-gcc 4.6: http://gcc.gnu.org/gcc-4.6/changes.html#c
