### PR TITLE
Removed duplicate definitions.

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -198,10 +198,13 @@ typedef struct __attribute__((__packed__)) {
 
 /** Interface TX function */
 typedef struct csp_iface_s csp_iface_t;
+
+/* Nexthop typedef:
+ * Note this has to match the nexthop type in the iface structure */
 typedef int (*nexthop_t)(struct csp_iface_s * interface, csp_packet_t *packet, uint32_t timeout);
 
 /** Interface struct */
-typedef struct csp_iface_s {
+struct csp_iface_s {
 	const char *name;			/**< Interface name (keep below 10 bytes) */
 	void * driver;				/**< Pointer to interface handler structure */
 	nexthop_t nexthop;			/**< Next hop function */
@@ -219,11 +222,7 @@ typedef struct csp_iface_s {
 	uint32_t rxbytes;			/**< Received bytes */
 	uint32_t irq;				/**< Interrupts */
 	struct csp_iface_s *next;	/**< Next interface */
-} csp_iface_t;
-
-/* Nexthop typedef:
- * Note this has to match the nexthop type in the iface structure */
-typedef int (*nexthop_t)(csp_iface_t * interface, csp_packet_t *packet, uint32_t timeout);
+};
 
 /**
  * This define must be equal to the size of the packet overhead in csp_packet_t.


### PR DESCRIPTION
Duplicate definitions in csp.h caused compile errors with some compiler versions.

Satlab PC is using a old avr-gcc
